### PR TITLE
Add group filtering for jobs cleaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Role Variables
 * `rundeck_api_token` the authentification token (mandatory).
 * `rundeck_api_version` api version supported by rundeck server. Default to 26.
 * `rundeck_remove_missing` Whether to delete jobs present in rundeck and not in file. Defaults to true.
+* `rundeck_jobs_group` the group of job to check for removal
 
 Dependencies
 ------------

--- a/tasks/rundeck.yml
+++ b/tasks/rundeck.yml
@@ -21,7 +21,7 @@
 
 - name: Get all jobs
   uri:
-    url: "{{rundeck_api_url }}/{{rundeck_api_version}}/project/{{ rundeck_project }}/jobs"
+    url: "{{rundeck_api_url }}/{{rundeck_api_version}}/project/{{ rundeck_project }}/jobs?groupPathExact={{ rundeck_jobs_group | default('""') }}"
     method: GET
     headers:
       Accept: application/json


### PR DESCRIPTION
Since we can use different groups for different environments we delete other environment jobs at each run. This PR adds a variable to clean only the specified environment. If not specified we keep old behaviour of getting all jobs from project.
![Brooming]( https://media.giphy.com/media/mG49oyuRW02is/giphy.gif )
Close #2 