### PR TITLE
dhall: Add a basic dhall type to be able to configure the role

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Role Variables
 * `rundeck_remove_missing` Whether to delete jobs present in rundeck and not in file. Defaults to true.
 * `rundeck_jobs_group` the group of job to check for removal
 
+A [dhall](https://dhall-lang.org/) Type representing the roles' variables is available in the `./dhall/Config.dhall` file to help you configure your projects with some type checking.
+
 Dependencies
 ------------
 

--- a/dhall/Config.dhall
+++ b/dhall/Config.dhall
@@ -1,0 +1,15 @@
+{ rundeck_jobs_path :
+	Text
+, rundeck_project :
+	Text
+, rundeck_api_url :
+	Text
+, rundeck_api_token :
+	Text
+, rundeck_api_version :
+	Optional Natural
+, rundeck_remove_missing :
+	Optional Bool
+, rundeck_jobs_group :
+	Optional Text
+}

--- a/dhall/Types.dhall
+++ b/dhall/Types.dhall
@@ -1,0 +1,1 @@
+{ Vault = ./Vault.dhall, Config = ./Config.dhall }

--- a/dhall/Vault.dhall
+++ b/dhall/Vault.dhall
@@ -1,0 +1,1 @@
+{ apiToken : Text }


### PR DESCRIPTION
This commit adds a basic Dhall type for an easier usage of this role.