### PR TITLE
Unmask Job creation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Role Variables
 * `rundeck_api_version` api version supported by rundeck server. Default to 26.
 * `rundeck_remove_missing` Whether to delete jobs present in rundeck and not in file. Defaults to true.
 * `rundeck_jobs_group` the group of job to check for removal
+* `rundeck_ignore_creation_errors` whether to ignore job creation error. Default to true to follow the 200 statu given by rundeck API
 
 A [dhall](https://dhall-lang.org/) Type representing the roles' variables is available in the `./dhall/Config.dhall` file to help you configure your projects with some type checking.
 
@@ -42,7 +43,7 @@ Including an example of how to use your role (for instance, with variables passe
 License
 -------
 
-TBD
+BSD
 
 Author Information
 ------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 rundeck_api_version: 26
 rundeck_remove_missing: true
+rundeck_ignore_creation_error: true

--- a/tasks/rundeck.yml
+++ b/tasks/rundeck.yml
@@ -19,6 +19,18 @@
   register: rundeck_create_jobs
   with_items: "{{ rundeck_jobs_files.files}}"
 
+- name: Check if a job failed
+  fail:
+    msg: "Job defined in {{ file }} has failed with message: {{ message }}"
+  with_items: "{{ rundeck_create_jobs.results }}"
+  loop_control:
+    label: "{{ item.item.path }}"
+  vars:
+    file: "{{ item.item.path }}"
+    message: "{{ item.json.failed }}"
+  when: item.json.failed|length > 0
+  ignore_errors: "{{ rundeck_ignore_creation_error }}"
+
 - name: Get all jobs
   uri:
     url: "{{rundeck_api_url }}/{{rundeck_api_version}}/project/{{ rundeck_project }}/jobs?groupPathExact={{ rundeck_jobs_group | default(rundeck_empty_group_path) }}"


### PR DESCRIPTION
The rundeck job creation api endpoint always return 200 with the result
in the body. The ansible action always succeed. This PR displays the
errors and if `rundeck_ignore_creation_error` is set to false, fails.